### PR TITLE
Attach email to payment method

### DIFF
--- a/subscribe.html
+++ b/subscribe.html
@@ -188,15 +188,14 @@
               <div class="col-md-2"></div>
               <div class="col-md-8">
                 <form id="subscription-form">
+                  <input class="form-control" type="email" id="email" name="email" placeholder="Email address" required>
                   <div id="card-element" class="MyCardElement">
                     <!-- Elements will create input elements here -->
                   </div>
 
                   <!-- We'll put the error messages in this element -->
                   <div id="card-errors" role="alert"></div>
-                  <div style="padding-top: 2em; text-align: center; font-size:75%;">
-                    By clicking subscribe you agree to our <a href="/terms" >terms of service</a>.
-                  </div>
+                  <small class="form-text text-muted" style="margin-top: 2em; text-align: center;">By clicking subscribe you agree to our <a href="/terms" >terms of service</a></small>
                   <div style="text-align: center;">
                     <button
                       style="margin-top: 2em; margin-bottom: 2em;"
@@ -358,11 +357,6 @@
         subscriptionForm.addEventListener("submit", function (evt) {
           evt.preventDefault();
 
-          // Create customer
-          //createCustomer().then((response) => {
-          //  customer = response.customer;
-          //  createPaymentMethod({ card: card, customerId: customer.Id });
-          // });
           createPaymentMethod({ card: card });
         });
       }
@@ -385,19 +379,17 @@
       customerId,
     }) {
       // Set up payment method for recurring usage
-      let billingName = document.querySelector("#name")
-        ? document.querySelector("#name").value
-        : "";
-
-      //let priceId = document.getElementById("priceId").innerHTML.toUpperCase();
+      let billingEmail = document.querySelector("#email")
+      ? document.querySelector("#email").value
+      : "";
 
       stripe
         .createPaymentMethod({
           type: "card",
           card: card,
-          //billing_details: {
-          //  name: billingName,
-          //},
+          billing_details: {
+            email: billingEmail,
+          },
         })
         .then((result) => {
           // result.error = "whaat"

--- a/subscribe.html
+++ b/subscribe.html
@@ -89,7 +89,7 @@
         background-color: #fefde5 !important;
     </style>
   </head>
-  <body>
+  <body onload="acceptParam()">
     <div class="container-fluid">
       <div class="row title">
         <div class="col-md-10 offset-md-1">
@@ -1039,6 +1039,19 @@
     function resetDemo() {
       clearCache();
       window.location.href = "/";
+    }
+
+    function acceptParam() {
+      var hashParams = window.location.href.split('?'); 
+          hashParams = hashParams[1].split('&');
+          hashParams.forEach(function(s) {
+            var p = s.split('=');
+            let elem = p[0]
+            let val = p[1]
+            if (document.getElementById(elem) !=null) {
+              document.getElementById(elem).value = val
+            }
+          })
     }
   </script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>


### PR DESCRIPTION
Capture the email of the user and attach to the payment method. Will allow us to correlate any payment methods we may have.

Autopopulate based off query string e.g. https://m3o.com/subscribe?email=dom@m3o.com